### PR TITLE
Add flatten test and use collections.abc.Iterable.

### DIFF
--- a/microdf/tests/test_utils.py
+++ b/microdf/tests/test_utils.py
@@ -4,9 +4,9 @@ import pandas as pd
 
 
 def test_cartesian_product():
-    res = cartesian_product({'a': [1, 2, 3],
-                             'b': ['val1', 'val2'],
-                             'c': [100, 101]})
+    res = mdf.cartesian_product({'a': [1, 2, 3],
+                                 'b': ['val1', 'val2'],
+                                 'c': [100, 101]})
     EXPECTED = pd.DataFrame({'a': [1, 1, 1, 1, 2, 2, 2, 2,
                                    3, 3, 3, 3],
                              'b': ['val1', 'val1', 'val2', 'val2',
@@ -15,3 +15,10 @@ def test_cartesian_product():
                              'c': [100, 101, 100, 101, 100, 101,
                                    100, 101, 100, 101, 100, 101]})
     pd.testing.assert_frame_equal(res, EXPECTED)
+
+
+def test_flatten():
+    L = [[[1, 2, 3], [4, 5]], 6]
+    res = list(mdf.flatten(L))
+    EXPECTED = [1, 2, 3, 4, 5, 6]
+    assert res == EXPECTED

--- a/microdf/utils.py
+++ b/microdf/utils.py
@@ -366,7 +366,7 @@ def flatten(l):
         Flattened version.
     """
     for el in l:
-        if isinstance(el, collections.Iterable) and not isinstance(el, (str, bytes)):
+        if isinstance(el, collections.abc.Iterable) and not isinstance(el, (str, bytes)):
             yield from flatten(el)
         else:
             yield el

--- a/microdf/utils.py
+++ b/microdf/utils.py
@@ -366,7 +366,8 @@ def flatten(l):
         Flattened version.
     """
     for el in l:
-        if isinstance(el, collections.abc.Iterable) and not isinstance(el, (str, bytes)):
+        if isinstance(el, collections.abc.Iterable) \
+           and not isinstance(el, (str, bytes)):
             yield from flatten(el)
         else:
             yield el


### PR DESCRIPTION
Attempts to fix #46, and also adds a test for `flatten`. Right now, the warning is gone when used in isolation (i.e., copying the `flatten` code into ipython), but not when running pytest on the whole package.